### PR TITLE
Replace distutils with packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 build-backend = "setuptools.build_meta"
 requires = [
     "cmake>=3.10",
+    "packaging",
     "setuptools>=42",
     "wheel",
 ]

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 import platform
 import subprocess
 
-from distutils.version import LooseVersion
+from packaging.version import Version
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
 from shutil import copyfile
@@ -25,8 +25,8 @@ class CMakeBuild(build_ext):
                 ", ".join(e.name for e in self.extensions))
 
         if platform.system() == "Windows":
-            cmake_version = LooseVersion(re.search(r'version\s*([\d.]+)',
-                                         out.decode()).group(1))
+            cmake_version = Version(re.search(r'version\s*([\d.]+)',
+                                    out.decode()).group(1))
             if cmake_version < '3.10.0':
                 raise RuntimeError("CMake >= 3.10.0 is required on Windows")
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ class CMakeBuild(build_ext):
         if platform.system() == "Windows":
             cmake_version = Version(re.search(r'version\s*([\d.]+)',
                                     out.decode()).group(1))
-            if cmake_version < '3.10.0':
+            if cmake_version < Version('3.10.0'):
                 raise RuntimeError("CMake >= 3.10.0 is required on Windows")
 
         for ext in self.extensions:


### PR DESCRIPTION
Use of `distutils` is deprecated and the recommended replacement for `distutils.version.LooseVersion` is `packaging.version.Version`.

We only use this in the Windows build to check the `cmake` version, so will need to build a set of wheels on CI to check the changes are OK here.