### PR TITLE
Bump version to 0.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## RTXpy Changelog
 ------------------
 
+### Version 0.0.8 - 21 February 2026
+- Replace build_wheels with release workflow using PYPI_TOKEN (#50)
+- Fix Windows: skip GLFW X11 platform hint on native Windows
+- Fix Windows crash: use OSError instead of termios.error in except clause
+- Fix Windows conda build: allow PyPI access for pyoptix-contrib install
+
 ### Version 0.0.3 - 11 November 2021
 - Changes for building on conda-forge, part 2
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rtxpy" %}
-{% set version = "0.0.7" %}
+{% set version = "0.0.8" %}
 
 package:
   name: {{ name|lower }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rtxpy"
-version = "0.0.7"
+version = "0.0.8"
 description = "Ray tracing using CUDA accessible from Python"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/rtxpy/__init__.py
+++ b/rtxpy/__init__.py
@@ -24,7 +24,7 @@ from .mesh_store import (
 from .analysis import viewshed, hillshade, render, flyover, view
 from .engine import explore
 
-__version__ = "0.0.7"
+__version__ = "0.0.8"
 
 # Optional convenience — network helpers with lazy dependency checks
 try:


### PR DESCRIPTION
## Summary
- Bump version to 0.0.8 in `pyproject.toml`, `rtxpy/__init__.py`, and `conda-recipe/meta.yaml`
- Update `CHANGELOG.md` with 0.0.8 release notes (Windows fixes, release workflow update)

## Test plan
- [ ] Verify version reads correctly: `python -c "import rtxpy; print(rtxpy.__version__)"`
- [ ] Confirm release workflow triggers on merge