### PR TITLE
bump version to 0.0.9

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rtxpy" %}
-{% set version = "0.0.8" %}
+{% set version = "0.0.9" %}
 
 package:
   name: {{ name|lower }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rtxpy"
-version = "0.0.8"
+version = "0.0.9"
 description = "Ray tracing using CUDA accessible from Python"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/rtxpy/__init__.py
+++ b/rtxpy/__init__.py
@@ -24,7 +24,7 @@ from .mesh_store import (
 from .analysis import viewshed, hillshade, render, flyover, view
 from .engine import explore
 
-__version__ = "0.0.8"
+__version__ = "0.0.9"
 
 # Optional convenience — network helpers with lazy dependency checks
 try:


### PR DESCRIPTION
## Summary
- Updated prebuilt PTX to use backward-compatible vertex data intrinsic (fixes Windows OptiX 7.7 runtime error)
- Bump version to 0.0.9

## Changes
- PTX recompiled with 4-param `optixGetTriangleVertexData` (works on all ABI versions)
- Version bumped in pyproject.toml, __init__.py, and conda recipe